### PR TITLE
Fix for goo.gl when key is needed. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ Simple services can be described using a string substitution link. Pass the enti
 	http://arseh.at/3yd
 
 Display the built-in command line documentation with `shorten --help`.
+
+## Changelog
+
+### 0.0.7 - Update to allow goo.gl to accept a key (docs were there but code didn't allow for it).

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var VERSION = '0.0.3',
+var VERSION = '0.0.7',
 	request = require('request'),
 	querystring = require('querystring').stringify;
 
@@ -74,8 +74,11 @@ var shorteners = {
 	},
 
 	'goo.gl': function(longurl, params, callback) {
+		var uri = params && params.key ? 
+		            'https://www.googleapis.com/urlshortener/v1/url?key=' + params.key : 
+		            'https://www.googleapis.com/urlshortener/v1/url';
 		request({
-			uri: 'https://www.googleapis.com/urlshortener/v1/url',
+			uri: uri,
 			method: 'POST',
 			json: {longUrl:longurl}
 		}, function(error, response, body) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 { "name": "shorturl-2"
-, "version": "v0.0.6"
+, "version": "v0.0.7"
 , "description": "Simple URL shortener client library"
 , "keywords": ["shorturl", "shortlink", "bit.ly", "bitly", "goo.gl", "is.gd"]
 , "author": "eceeb"


### PR DESCRIPTION
goo.gl shortener was returning undefined without a key. Adding the API key fixed the issue. Would prefer not to have my own library for this so here's a pull request. Tag you're it! ;)